### PR TITLE
Removing missing packages

### DIFF
--- a/download/linux.md
+++ b/download/linux.md
@@ -50,10 +50,6 @@ Usage
 
 The package ***monodevelop*** should be installed to get the main MonoDevelop application.
 
-Install ***monodevelop-nunit*** to get the MonoDevelop NUnit addin, so you can run unit tests inside the IDE.<br/>
-Install ***monodevelop-versioncontrol*** to add Git and SVN integration to the IDE.<br/>
-Install ***monodevelop-database*** to add the database addin to the IDE.
-
 openSUSE
 --------
 


### PR DESCRIPTION
The packages **_monodevelop-database**_, **_monodevelop-nunit**_ and **_monodevelop-versioncontrol**_ do not exist at the Fedora/CentOS repository.

http://download.mono-project.com/repo/centos/
