### PR TITLE
Fixed Bug-6304 Wrong link for downloading .NET Framework 4.0

### DIFF
--- a/download/index.md
+++ b/download/index.md
@@ -37,7 +37,7 @@ To install this release, you also need to install the following packages:
 
 To install this release, you also need to install the following packages:
 
-- .NET Framework 4.0: [Download](http://msdn.microsoft.com/en-US/netframework/aa569263.aspx)
+- .NET Framework 4.5: [Download](http://www.microsoft.com/en-in/download/details.aspx?id=30653)
 - GTK# for .NET 2.12.25: [Download](http://download.xamarin.com/GTKforWindows/Windows/gtk-sharp-2.12.25.msi)
 
 <a href="{{ page.latest_monodevelop_win }}" class="button radius"><i class="fa fa-download"></i> Download Xamarin Studio</a>

--- a/download/index.md
+++ b/download/index.md
@@ -37,7 +37,7 @@ To install this release, you also need to install the following packages:
 
 To install this release, you also need to install the following packages:
 
-- .NET Framework 4.0: [Download](http://www.microsoft.com/download/en/details.aspx?displaylang=en&id=8279)
+- .NET Framework 4.0: [Download](http://msdn.microsoft.com/en-US/netframework/aa569263.aspx)
 - GTK# for .NET 2.12.25: [Download](http://download.xamarin.com/GTKforWindows/Windows/gtk-sharp-2.12.25.msi)
 
 <a href="{{ page.latest_monodevelop_win }}" class="button radius"><i class="fa fa-download"></i> Download Xamarin Studio</a>


### PR DESCRIPTION
The link here redirects to the windows sdk download page , i have fixed it to the download page of .net framework
