### PR TITLE
Correct "using" block

### DIFF
--- a/developers/articles/creating-a-simple-add-in.md
+++ b/developers/articles/creating-a-simple-add-in.md
@@ -176,6 +176,7 @@ Many important services can be accessed via the MonoDevelop.Ide.Gui.IdeApp stati
 First, import the namespaces:
 
 ``` csharp
+using MonoDevelop.Ide;
 using MonoDevelop.Ide.Gui;
 using MonoDevelop.Ide.Gui.Content;
 using Mono.TextEditor;


### PR DESCRIPTION
The code in the article refers to "IdeApp.Workbench.ActiveDocument;" which is in:

```
using MonoDevelop.Ide;
```

And it is not currently in the code sample:

```
using MonoDevelop.Ide.Gui;
using MonoDevelop.Ide.Gui.Content;
using Mono.TextEditor;
```
