### PR TITLE
Fixed links & added link about project templates

### DIFF
--- a/developers/articles/index.md
+++ b/developers/articles/index.md
@@ -15,34 +15,37 @@ Our website is open source on [GitHub](https://github.com/mono/md-website). If y
 Building MonoDevelop
 --------------------
 
-[Development: Getting Started](/developers/articles/development-getting-started/)<br/>
+[Development: Getting Started](/developers/articles/development-getting-started.md)<br/>
 It's relatively easy to get started working on MonoDevelop, but this article aims to make it easier to get off the ground.
 
-[Environment Variables](/developers/articles/environment-variables/)<br/>
+[Environment Variables](/developers/articles/environment-variables.md)<br/>
 An in-depth explanation of all environment variables that can be altered in order to simplify the development of MonoDevelop. 
 
-[Building MonoDevelop from source](/developers/building-monodevelop/)<br/>
+[Building MonoDevelop from source](/developers/building-monodevelop.md)<br/>
 Basic steps for building MonoDevelop. 
 
 Writing Add-ins
 ---------------
 
-[Creating a Simple Add-in](/developers/articles/creating-a-simple-add-in/)<br/>
+[Creating a Simple Add-in](/developers/articles/creating-a-simple-add-in.md)<br/>
 This walkthrough will guide you through the process of creating a simple add-in, introducing the fundamentals of the add-in system and some of MonoDevelop's core APIs.
 
-[Walk through: Extending the Project Pad](/developers/articles/extending-the-project-pad/)<br/>
+[Creating a Simple Project template](/developers/articles/creating%20a%20simple%20project%20template.md)<br/>
+This walkthrough will guide you through the process of creating a simple project template using add ins.
+
+[Walk through: Extending the Project Pad](/developers/articles/extending-the-project-pad.md)<br/>
 This tutorial explains how to implement an addin that extends the project pad. The idea for this extension is to be able to show the classes that are implemented in a file as child nodes of that file in the project pad.
 
-[How to extend the Project Model](/developers/articles/how-to-extend-the-project-model/)<br/>
+[How to extend the Project Model](/developers/articles/how-to-extend-the-project-model.md)<br/>
 This article explains how to extend the project model to support new types of projects or to add additional information to existing project types.
 
-[Syntax mode definition](/developers/articles/syntax-mode-definition/)<br/>
+[Syntax mode definition](/developers/articles/syntax-mode-definition.md)<br/>
 This article explains how to create a syntax highlighting mode for a new file type.
 
-[Editor color scheme definition](/developers/articles/color-scheme-definition/)<br/>
+[Editor color scheme definition](/developers/articles/color-scheme-definition.md)<br/>
 This article explains how to create a syntax highlighting mode for a new file type.
 
-[Publishing an Add-in](/developers/articles/publishing-an-addin/)<br/>
+[Publishing an Add-in](/developers/articles/publishing-an-addin.md)<br/>
 This article explains how to publish an add-in to make it available to MonoDevelop users.
 
 [Introduction to Mono.Addins](http://www.mono-project.com/Introduction_to_Mono.Addins)<br/>
@@ -54,52 +57,52 @@ An in-depth explanation of all Mono.Addins features. Mono.Addins is the add-in e
 MonoDevelop API
 ---------------
 
-[API Overview](/developers/articles/api-overview/)<br/>
+[API Overview](/developers/articles/api-overview.md)<br/>
 An overview of the MonoDevelop API, explaining where to find the most important services and how to use them.
 
-[Using the Data Serializer](/developers/articles/using-the-data-serializer/)<br/>
+[Using the Data Serializer](/developers/articles/using-the-data-serializer.md)<br/>
 A programming guide of the generic data serializer provided by the MonoDevelop API.
 
-[The String Parser Service](/developers/articles/the-string-parser-service/)<br/>
+[The String Parser Service](/developers/articles/the-string-parser-service.md)<br/>
 A programming guide for the String Parser Service.
 
-[Logging](/developers/articles/logging/)<br/>
+[Logging](/developers/articles/logging.md)<br/>
 MonoDevelop's logging service provides a configurable way for developers to log debug and error messages reported by Addins.
 
-[Project Templates](/developers/articles/project-templates/)<br/>
+[Project Templates](/developers/articles/project-templates.md)<br/>
 A guide on how to integrate with the New Project dialog and implement project template wizard pages.
 
 MonoDevelop Design and Architecure
 ----------------------------------
 
-[Architecture Overview](/developers/articles/architecture-overview/)<br/>
+[Architecture Overview](/developers/articles/architecture-overview.md)<br/>
 This document is an overview of the new assembly organization of MonoDevelop.
 
-[The Project Model](/developers/articles/the-project-model/)<br/>
+[The Project Model](/developers/articles/the-project-model.md)<br/>
 This document describes the MonoDevelop Project Model.
 
-[Add-in Extension Tree Reference](/developers/articles/extension-tree-reference/)<br/>
+[Add-in Extension Tree Reference](/developers/articles/extension-tree-reference.md)<br/>
 This document shows the complete extension tree available to add-in developers.
 
-[Error and Exception Handling](/developers/articles/error-and-exception-handling/)<br/>
+[Error and Exception Handling](/developers/articles/error-and-exception-handling.md)<br/>
 This document explains how to handle errors and how to show them to the user.
 
-[The Command System](/developers/articles/the-command-system/)<br/>
+[The Command System](/developers/articles/the-command-system.md)<br/>
 This article explains how MonoDevelop's Command System works, and how can you take advantage of it for writing your add-ins.
 
-[Thread Management in MonoDevelop](/developers/articles/thread-management/)<br/>
+[Thread Management in MonoDevelop](/developers/articles/thread-management.md)<br/>
 This article explains the some basic rules that every addin developer should follow regarding thread management in MonoDevelop.
 
-[Translations](/developers/articles/translations/)<br/>
+[Translations](/developers/articles/translations.md)<br/>
 MonoDevelop has chosen to use gettext instead of resources for translating into other languages. This allows us to take advantage of GNOME translators' familiarity with gettext.
 
-[Refactoring](/developers/articles/refactoring/)<br/>
+[Refactoring](/developers/articles/refactoring.md)<br/>
 This article explains the MonoDevelop refactoring infrastructure. It helps writing own refactorings.
 
-[The Toolbox](/developers/articles/toolbox/)<br/>
+[The Toolbox](/developers/articles/toolbox.md)<br/>
 MonoDevelop has some infrastructure for supporting visual designers, such as the ASP.NET and Gtk# designers. Some of this — the property grid and toolbox — is now being used elsewhere in MonoDevelop.
 
 Obsolete Articles
 -----------------
 
-In the [Obsolete Articles](/archived/developers/articles/obsolete-articles/) section you'll find some outdated articles which are kept just as a reference.
+In the [Obsolete Articles](/archived/developers/articles/obsolete-articles) section you'll find some outdated articles which are kept just as a reference.


### PR DESCRIPTION
Links were broken and didn't have the .md suffix.
Also there was an article about creating simple project templates using add-ins but wasn't yet added to the index file.

Note: the article "Creating a Simple Project template" is not the same as the project templates article. The project templates article only explains the structure, but does not explain how to create a simple project template.