### PR TITLE
Fix typo on the Feature List page

### DIFF
--- a/documentation/feature-list/index.md
+++ b/documentation/feature-list/index.md
@@ -5,7 +5,7 @@ redirect_from:
   - /Feature_List/
 ---
 
-The following matrix shows which features are available for each platform. MonoDevelop features not shown in the list ara available for all platforms.
+The following matrix shows which features are available for each platform. MonoDevelop features not shown in the list are available for all platforms.
 
 | **Feature**              | **Linux**                              | **Mac**                                 | **Windows**                             |
 |--------------------------|----------------------------------------|-----------------------------------------|-----------------------------------------|


### PR DESCRIPTION
Fixes the following typo on the Feature List page:

Changes:
> The following matrix shows which features are available for each platform. MonoDevelop features not shown in the list __ara__ available for all platforms.

to:
> The following matrix shows which features are available for each platform. MonoDevelop features not shown in the list __are__ available for all platforms.