### PR TITLE
Add missing build dependency of F#

### DIFF
--- a/developers/building-monodevelop.md
+++ b/developers/building-monodevelop.md
@@ -20,6 +20,7 @@ MonoDevelop requires the following packages (or newer versions):
 -   Mono.Addins 0.6
 -   Gtk# 2.12.45
 -   monodoc 1.0
+-   F# (`fsharpc` program)
 -   cmake
 -   libssh2
 


### PR DESCRIPTION
I tried to build monodevelop on Ubuntu, but the `configure` step failed because it couldn't find `fsharpc`, the F# compiler.  This was fixed on my environment by installing the `fsharp` package.