### PR TITLE
Remove "Mono Libraries for Windows" reference

### DIFF
--- a/developers/building-monodevelop.md
+++ b/developers/building-monodevelop.md
@@ -172,7 +172,6 @@ Windows
 ### Prerequisites and Source
 
 -   Install Gtk# ([installer](http://www.mono-project.com/download/#download-win)).
--   Install the Mono libraries package ([installer](https://files.xamarin.com/~jeremie/MonoLibraries.msi))
 -   Install Visual Studio 2017 with the .NET Desktop and .NET Core workloads and the F# optional component (note, F# is disabled by default so need to enable it in the VS installer).
 -   Install Git for Windows (from [here](https://git-for-windows.github.io/))
 -   Install GNU Gettext tools (from [here](http://gnuwin32.sourceforge.net/packages/gettext.htm))


### PR DESCRIPTION
This is a .msi with some random libs from Mono 2.6 (!), and is not needed to build MonoDevelop git master in VS2017. Any functionality which fails to compile without those libs in the GAC should be fixed in other ways.