### PR TITLE
Updated Run() example to use the System namespace

### DIFF
--- a/developers/articles/creating-a-simple-add-in.md
+++ b/developers/articles/creating-a-simple-add-in.md
@@ -199,7 +199,7 @@ Now we can implement the command's Run method, which, unsurprisingly, is called 
 protected override void Run ()
 {
     MonoDevelop.Ide.Gui.Document doc = IdeApp.Workbench.ActiveDocument;
-    string date = DateTime.Now.ToString ();
+    string date = System.DateTime.Now.ToString ();
     doc.Editor.InsertAtCaret (date);
 }
 ```


### PR DESCRIPTION
Following the example, the user will not have added the System namespace yet. This avoids a compile error.