### PR TITLE
Remove Google Analytics

### DIFF
--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -23,21 +23,6 @@
         window.location.replace(window.location.href.replace("mono.github.io/md-website", "www.monodevelop.com"));
       }
     </script>
-    <script>
-      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)})(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-
-      function enableGA() {
-        ga('set', 'anonymizeIp', true);
-        ga('create', 'UA-1871338-2', 'auto');
-        ga('send', 'pageview');
-      }
-
-      if (typeof(mscc) === 'undefined' || mscc.hasConsent()) {
-        enableGA();
-      } else {
-        mscc.on('consent', enableGA);
-      }
-    </script>
   </head>
   <body>
     <div id="header" class="contain-to-grid">


### PR DESCRIPTION
## Remove Google Analytics

This commit removes the Google Analytics 'functionality' from this page. Following on
from the previous commit, this change also greatly improves the privacy of 
unsuspecting users.

If you must have an analytics system, might I suggest either:
- Plausible: https://plausible.io (offers a 50% discount for FOSS projects)
- Goatcounter: https://goatcounter.com
- Matomo: https://matomo.org
- Fathom: https://usefathom.org

These solutions are all well-tested and open-source. This, of course, means they
can be independently audited for privacy and security. Instead of using a proprietary
nonfree system such as Google Analytics, perhaps we could work together to replace
it with something slightly more ethical?

Furthermore, the majority of privacy features in evergreen browsers *block* Google
Analytics from being run. I can not say the same for solutions such as Plausible,
which suggests they are trusted for their privacy by independent persons.

Thankfully, this change is relatively easy to make, as you have a brilliant
taste in build tools! Jekyll is, thankfully, rather easy to work with.